### PR TITLE
Relax version updates plugin dependency

### DIFF
--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -22,5 +22,6 @@ dependencies {
 
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.github.ben-manes:gradle-versions-plugin:0.39.0'
+    testImplementation(gradleTestKit())
     compileOnly 'com.github.ben-manes:gradle-versions-plugin:0.39.0'
 }


### PR DESCRIPTION
All the plugin needs is the json report from the version updates plugin. It can either be set by the plugin when the version updates plugin is applied, or set manually for testing or when the report json is created by some other means (maybe another plugin in the future?)

Only if the report json is missing, an error is emitted that the version updates plugin needs to be applied.