### PR TITLE
Plugin detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+Version 0.2.2-SNAPSHOT
+-------------
+* Fixes an issue where plugin dependencies were incorrectly classified as libraries when using a `resolutionStrategy` mapping plugin ids. [(#11)](https://github.com/littlerobots/version-catalog-update-plugin/issues/11)
+
 Version 0.2.1
 --------------
 * Use the preferred version for `exceeded` dependencies in the toml file. [(#7)](https://github.com/littlerobots/version-catalog-update-plugin/issues/7)

--- a/catalog/src/main/kotlin/nl/littlerobots/vcu/model/VersionCatalog.kt
+++ b/catalog/src/main/kotlin/nl/littlerobots/vcu/model/VersionCatalog.kt
@@ -147,7 +147,7 @@ private fun VersionCatalog.retainCurrentVersionReferences(
 /**
  * Updates plugins for this catalog
  *
- * This will move any plugins matching the module id from libraries to plugins if that plugin
+ * This will add any plugins matching the module id in the libraries section to plugins if that plugin
  * is not declared yet in the catalog.
  *
  * @param plugins a map of pluginId to its Maven module
@@ -168,7 +168,7 @@ fun VersionCatalog.mapPlugins(
     }.toMap()
 
     // already known plugin ids which we won't touch, assuming those are discovered by other means
-    val pluginIds = this.plugins.values.map { it.id }
+    val pluginIds = this.plugins.values.map { it.id }.toSet()
 
     val addedPlugins = plugins.toMutableMap().apply { keys.removeAll(pluginIds) }
     val newPlugins = this.plugins + addedPlugins.mapNotNull { entry ->

--- a/catalog/src/main/kotlin/nl/littlerobots/vcu/versions/VersionReportParser.kt
+++ b/catalog/src/main/kotlin/nl/littlerobots/vcu/versions/VersionReportParser.kt
@@ -37,7 +37,7 @@ class VersionReportParser {
         .addLast(KotlinJsonAdapterFactory()).build()
 
     fun generateCatalog(versionsJson: InputStream): VersionCatalog {
-        val adapter = moshi.adapter<VersionsReport>(VersionsReport::class.java)
+        val adapter = moshi.adapter(VersionsReport::class.java)
         val report = versionsJson.use {
             adapter.fromJson(it.source().buffer())!!
         }


### PR DESCRIPTION
Get build script dependencies for all subprojects, so that the plugin is able to resolve plugin artifacts that are applied using `plugin` syntax, but have their id mapped through a `resolutionStrategy`. 

Because those plugins are not added as a dependency to the root build script which has the version catalog update plugin applied, they wouldn't be considered as plugins and updates to the catalog would remove the plugins again as a result.