### PR TITLE
Keep toml file comments

### DIFF
--- a/catalog/src/main/kotlin/nl/littlerobots/vcu/VersionCatalogWriter.kt
+++ b/catalog/src/main/kotlin/nl/littlerobots/vcu/VersionCatalogWriter.kt
@@ -26,8 +26,14 @@ class VersionCatalogWriter {
     fun write(versionCatalog: VersionCatalog, writer: Writer) {
         val printWriter = PrintWriter(writer)
         if (versionCatalog.versions.isNotEmpty()) {
+            for (line in versionCatalog.versionComments.tableComments) {
+                printWriter.println(line)
+            }
             printWriter.println("[versions]")
             for (version in versionCatalog.versions) {
+                for (comment in versionCatalog.versionComments.getCommentsForKey(version.key)) {
+                    printWriter.println(comment)
+                }
                 printWriter.println("""${version.key} = ${formatVersion(version.value)}""")
             }
         }
@@ -35,8 +41,14 @@ class VersionCatalogWriter {
             if (versionCatalog.versions.isNotEmpty()) {
                 printWriter.println()
             }
+            for (line in versionCatalog.libraryComments.tableComments) {
+                printWriter.println(line)
+            }
             printWriter.println("[libraries]")
             for (library in versionCatalog.libraries) {
+                for (comment in versionCatalog.libraryComments.getCommentsForKey(library.key)) {
+                    printWriter.println(comment)
+                }
                 printWriter.println("""${library.key} = ${formatLibrary(library.value)}""")
             }
         }
@@ -44,8 +56,14 @@ class VersionCatalogWriter {
             if (versionCatalog.versions.isNotEmpty() || versionCatalog.libraries.isNotEmpty()) {
                 printWriter.println()
             }
+            for (comment in versionCatalog.bundleComments.tableComments) {
+                printWriter.println(comment)
+            }
             printWriter.println("[bundles]")
             for (bundle in versionCatalog.bundles) {
+                for (comment in versionCatalog.bundleComments.getCommentsForKey(bundle.key)) {
+                    printWriter.println(comment)
+                }
                 printWriter.println(
                     "${bundle.key} = [${
                     bundle.value.joinToString(
@@ -59,8 +77,14 @@ class VersionCatalogWriter {
             if (versionCatalog.versions.isNotEmpty() || versionCatalog.bundles.isNotEmpty() || versionCatalog.libraries.isNotEmpty()) {
                 printWriter.println()
             }
+            for (comment in versionCatalog.pluginComments.tableComments) {
+                printWriter.println(comment)
+            }
             printWriter.println("[plugins]")
             for (plugin in versionCatalog.plugins) {
+                for (comment in versionCatalog.pluginComments.getCommentsForKey(plugin.key)) {
+                    printWriter.println(comment)
+                }
                 printWriter.println("${plugin.key} = ${formatPlugin(plugin.value)}")
             }
         }

--- a/catalog/src/main/kotlin/nl/littlerobots/vcu/model/VersionCatalog.kt
+++ b/catalog/src/main/kotlin/nl/littlerobots/vcu/model/VersionCatalog.kt
@@ -21,7 +21,11 @@ data class VersionCatalog(
     val versions: Map<String, VersionDefinition>,
     val libraries: Map<String, Library>,
     val bundles: Map<String, List<String>>,
-    val plugins: Map<String, Plugin>
+    val plugins: Map<String, Plugin>,
+    val versionComments: Comments = Comments(),
+    val libraryComments: Comments = Comments(),
+    val bundleComments: Comments = Comments(),
+    val pluginComments: Comments = Comments(),
 ) {
     /**
      * The effective version definition of a [HasVersion], resolving [VersionDefinition.Reference]
@@ -38,6 +42,13 @@ data class VersionCatalog(
                 version
             }
         }
+}
+
+data class Comments(
+    val tableComments: List<String> = emptyList(),
+    val entryComments: Map<String, List<String>> = emptyMap()
+) {
+    fun getCommentsForKey(key: String) = entryComments[key] ?: emptyList()
 }
 
 /**

--- a/catalog/src/test/kotlin/nl/littlerobots/vcu/VersionCatalogParserTest.kt
+++ b/catalog/src/test/kotlin/nl/littlerobots/vcu/VersionCatalogParserTest.kt
@@ -265,4 +265,28 @@ class VersionCatalogParserTest {
             result.libraries["lib"]!!
         )
     }
+
+    @Test
+    fun `records comments on tables and entries`() {
+        val toml = """
+            # Nice comment
+            [libraries] # valid, but not retained
+            # Comment for lib
+            # Even more comments
+            lib = { module = "nl.littlerobots.test:test" }
+
+            [bundles]
+            # test bundle comment
+            test = ["lib"]
+
+            # this is a trailing comment
+        """.trimIndent()
+
+        val parser = VersionCatalogParser()
+        val result = parser.parse(toml.byteInputStream())
+
+        assertEquals(listOf("# Nice comment"), result.libraryComments.tableComments)
+        assertEquals(listOf("# Comment for lib", "# Even more comments"), result.libraryComments.entryComments["lib"])
+        assertEquals(listOf("# test bundle comment"), result.bundleComments.entryComments["test"])
+    }
 }

--- a/catalog/src/test/kotlin/nl/littlerobots/vcu/VersionCatalogWriterTest.kt
+++ b/catalog/src/test/kotlin/nl/littlerobots/vcu/VersionCatalogWriterTest.kt
@@ -231,4 +231,57 @@ class VersionCatalogWriterTest {
             writer.toString()
         )
     }
+
+    @Test
+    fun `writes out comments`() {
+        val catalogWriter = VersionCatalogWriter()
+        val writer = StringWriter()
+
+        val toml = """
+            [versions]
+            # version comment
+            myversion = "1.0.0"
+            #something else
+            test = "2.0"
+            # Nice comment
+            [libraries] # valid, but not retained
+            # Comment for lib
+            # Even more comments
+            lib = { module = "nl.littlerobots.test:test", version = "1.0" }
+
+            # Table comment for bundles
+            [bundles]
+            # test bundle comment
+            test = ["lib"]
+
+            # Table comment for plugins
+            [plugins]
+        """.trimIndent()
+
+        val catalog = VersionCatalogParser().parse(toml.byteInputStream())
+        catalogWriter.write(catalog, writer)
+
+        assertEquals(
+            """
+                [versions]
+                # version comment
+                myversion = "1.0.0"
+                #something else
+                test = "2.0"
+
+                # Nice comment
+                [libraries]
+                # Comment for lib
+                # Even more comments
+                lib = "nl.littlerobots.test:test:1.0"
+
+                # Table comment for bundles
+                [bundles]
+                # test bundle comment
+                test = ["lib"]
+
+            """.trimIndent(),
+            writer.toString()
+        )
+    }
 }

--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogMetadata.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogMetadata.kt
@@ -1,0 +1,40 @@
+/*
+* Copyright 2021 Hugo Visser
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package nl.littlerobots.vcu.plugin
+
+import nl.littlerobots.vcu.model.Comments
+
+private val PIN_REGEX = Regex("#\\s?(?:@pin|@pinned)(?:\$|\\s.*)")
+private val KEEP_REGEX = Regex("#\\s?@keep(?:\$|\\s.*)")
+
+internal fun Comments.getPinnedKeys(): Set<String> {
+    return getMatchingKeys(PIN_REGEX)
+}
+
+internal fun Comments.getKeptKeys(): Set<String> {
+    return getMatchingKeys(KEEP_REGEX)
+}
+
+private fun Comments.getMatchingKeys(regex: Regex): Set<String> {
+    return entryComments.filter {
+        it.value.any {
+            comment ->
+            comment.matches(regex)
+        }
+    }.map {
+        it.key
+    }.toSet()
+}


### PR DESCRIPTION
Do a crude pass for locating comments and write them out to the toml file.
Comments are associated with toml table declarations and keys within the tables, so they can move around and be removed if a key or a whole table is removed.

Only comments that start on a new line are supported, and any trailing comments in the file will still be stripped.