### PR TITLE
Extract updateCatalog logic to proper methods

### DIFF
--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateTask.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateTask.kt
@@ -256,10 +256,10 @@ abstract class VersionCatalogUpdateTask @Inject constructor() : DefaultTask() {
                     }
                     project.logger.warn(
                         " - ${dependency.group}:${dependency.name} (libs.${
-                            declaredCatalogEntry.key.replace(
-                                '-',
-                                '.'
-                            )
+                        declaredCatalogEntry.key.replace(
+                            '-',
+                            '.'
+                        )
                         })\n     requested: ${dependency.currentVersion}$versionRef, resolved: ${dependency.latestVersion}"
                     )
                 }


### PR DESCRIPTION
`updateCatalog` Method was doing a lot of different stuff like creating the new catalog and updating the catalog, so I extracted this logic to proper methods

getCurrentCatalog method
return a instance of the current VersionCatalog

getUpdatedCatalog method
return update the VersionCatalog

## Motivation
---
I want to add support for multiple toml updates, creating a PR doing all this changes would be to hard to validate, so I'm sending this one first