### PR TITLE
Add format task for formatting without updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+Version 0.4.1-SNAPSHOT
+-------------
+* Added `versionCatalogFormat` task for formatting only, without updating dependencies. [(#48)](https://github.com/littlerobots/version-catalog-update-plugin/issues/48)
+
 Version 0.4.0
 -------------
 * Retain comments in TOML file (with some limitations) [(#18)](https://github.com/littlerobots/version-catalog-update-plugin/issues/18)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ To update the catalog file at any time run `./gradlew versionCatalogUpdate`. Thi
 No new entries will be added to the catalog, but unused entries will be removed. Any dependency that is not reported by the versions plugin, but still appears
 in the version catalog file will be considered unused. This is [configurable](#configuration).
 
+### Formatting only
+To format the existing `libs.versions.toml` file without updating library versions, you can run `./gradlew versionCatalogFormat`.
+This will format the version catalog and create new version references, just like the `versionCatalogUpdate` task would do.
+This comes in handy when you added an entry to the version catalog, but aren't ready yet to update any dependencies.
+
 ## Informational output
 In some cases the plugin will output some additional messages when checking for updates.
 

--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogFormatTask.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogFormatTask.kt
@@ -1,0 +1,55 @@
+/*
+* Copyright 2021 Hugo Visser
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package nl.littlerobots.vcu.plugin
+
+import nl.littlerobots.vcu.VersionCatalogParser
+import nl.littlerobots.vcu.VersionCatalogWriter
+import nl.littlerobots.vcu.model.sortKeys
+import nl.littlerobots.vcu.model.updateFrom
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+import javax.inject.Inject
+
+abstract class VersionCatalogFormatTask @Inject constructor() : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val catalogFile: RegularFileProperty
+
+    @get:Input
+    @get:Optional
+    abstract val sortByKey: Property<Boolean>
+
+    @TaskAction
+    fun formatCatalogFile() {
+        val catalog = VersionCatalogParser().parse(catalogFile.get().asFile.inputStream())
+        // run an "update" to group versions
+        val updated = catalog.updateFrom(catalog).let {
+            if (sortByKey.getOrElse(true)) {
+                it.sortKeys()
+            } else {
+                it
+            }
+        }
+        VersionCatalogWriter().write(updated, catalogFile.get().asFile.writer())
+    }
+}

--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateTask.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateTask.kt
@@ -42,6 +42,8 @@ import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
@@ -52,6 +54,7 @@ import javax.inject.Inject
 private const val PROPERTIES_SUFFIX = ".properties"
 
 abstract class VersionCatalogUpdateTask @Inject constructor() : DefaultTask() {
+    @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFile
     abstract val reportJson: RegularFileProperty
 

--- a/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogFormatPluginTest.kt
+++ b/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogFormatPluginTest.kt
@@ -1,0 +1,79 @@
+/*
+* Copyright 2021 Hugo Visser
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package nl.littlerobots.vcu.plugin
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class VersionCatalogFormatPluginTest {
+    @get:Rule
+    val tempDir = TemporaryFolder()
+    lateinit var buildFile: File
+
+    @Before
+    fun setup() {
+        buildFile = tempDir.newFile("build.gradle")
+    }
+
+    @Test
+    fun `formats the version catalog`() {
+        buildFile.writeText(
+            """
+            plugins {
+                id "nl.littlerobots.version-catalog-update"
+            }
+
+            // disable to forego the versions plugin requirement
+            tasks.named("versionCatalogUpdate").configure {
+                it.enabled = false
+            }
+            """.trimIndent()
+        )
+
+        val toml = """
+                [libraries]
+                test = { module = "some.dependency:test", version = "1.0.0" }
+                androidx-test-junit4 = "androidx.compose.ui:ui-test-junit4:1.1.0-rc02"
+
+        """.trimIndent()
+
+        File(tempDir.root, "gradle").mkdir()
+        File(tempDir.root, "gradle/libs.versions.toml").writeText(toml)
+
+        GradleRunner.create()
+            .withProjectDir(tempDir.root)
+            .withArguments("versionCatalogFormat")
+            .withPluginClasspath()
+            .build()
+
+        val libs = File(tempDir.root, "gradle/libs.versions.toml").readText()
+
+        assertEquals(
+            """
+            [libraries]
+            androidx-test-junit4 = "androidx.compose.ui:ui-test-junit4:1.1.0-rc02"
+            test = "some.dependency:test:1.0.0"
+
+            """.trimIndent(),
+            libs
+        )
+    }
+}

--- a/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdatePluginTest.kt
+++ b/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdatePluginTest.kt
@@ -57,6 +57,27 @@ class VersionCatalogUpdatePluginTest {
     }
 
     @Test
+    fun `plugin does not require versions plugin if upgrade task is disabled`() {
+        buildFile.writeText(
+            """
+            plugins {
+                id "nl.littlerobots.version-catalog-update"
+            }
+
+            tasks.named("versionCatalogUpdate").configure {
+                it.enabled = false
+            }
+            """.trimIndent()
+        )
+
+        GradleRunner.create()
+            .withProjectDir(tempDir.root)
+            .withArguments("versionCatalogUpdate")
+            .withPluginClasspath()
+            .build()
+    }
+
+    @Test
     fun `plugins with plugin block syntax in subprojects are detected`() {
         val reportJson = tempDir.newFile()
 
@@ -557,7 +578,7 @@ class VersionCatalogUpdatePluginTest {
         // force creation and configuration of dependent task
         project.tasks.getByName("dependencyUpdates")
 
-        val task = project.tasks.getByName(TASK_NAME) as VersionCatalogUpdateTask
+        val task = project.tasks.getByName(UPDATE_TASK_NAME) as VersionCatalogUpdateTask
         assertNotNull(task.reportJson.orNull)
     }
 


### PR DESCRIPTION
* Add a new task for formatting only
* Disable versions plugin check when the update task is disabled, for cases where only formatting is needed

Fixes #48