### PR TITLE
Ignore unused kept plugins/libraries when checking for updated pins

### DIFF
--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateTask.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateTask.kt
@@ -172,9 +172,12 @@ abstract class VersionCatalogUpdateTask @Inject constructor() : DefaultTask() {
             resolvedVersions.libraries.values.any {
                 it.group == pin.group
             }
-        }.map { lib ->
-            lib to catalogWithResolvedPlugins.libraries.entries.first {
+        }.mapNotNull { lib ->
+            // can be null for kept, but unused libraries
+            catalogWithResolvedPlugins.libraries.entries.firstOrNull {
                 it.value.group == lib.group
+            }?.let {
+                lib to it
             }
         }.filter {
             it.first.version != it.second.value.version && it.first.version is VersionDefinition.Simple
@@ -217,9 +220,12 @@ abstract class VersionCatalogUpdateTask @Inject constructor() : DefaultTask() {
             resolvedVersions.plugins.values.any {
                 it.id == pin.id
             }
-        }.map { plugin ->
-            plugin to catalogWithResolvedPlugins.plugins.entries.first {
+        }.mapNotNull { plugin ->
+            // can be null for kept, but unused plugins
+            catalogWithResolvedPlugins.plugins.entries.firstOrNull() {
                 it.value.id == plugin.id
+            }?.let {
+                plugin to it
             }
         }.filter {
             it.first.version != it.second.value.version && it.first.version is VersionDefinition.Simple


### PR DESCRIPTION
When plugins or libraries are both pinned and kept, and no longer used the look up in the updated catalog would fail because the dependency versions plugin no longer reports those versions. If the updated catalog does not contain a particular dependency, we just ignore the entry because there are no details about that dependency to generate the pin warnings.

Fixes #61