### PR TITLE
Use shadow plugin to relocate 3rd party dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+Version 0.5.4
+-------------
+* Shadow (bundle) dependencies to prevent conflicts with other plugins [(#39)](https://github.com/littlerobots/version-catalog-update-plugin/issues/39)
+
 Version 0.5.3
 -------------
 * Fix an issue with unused kept pinned dependencies causing the update task to fail [(#61)](https://github.com/littlerobots/version-catalog-update-plugin/issues/61)

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id "com.diffplug.spotless"
     id "com.vanniktech.maven.publish"
+    id "org.jetbrains.kotlin.jvm" apply false
 }
 
 apply from: 'gradle/spotless.gradle'

--- a/catalog/build.gradle
+++ b/catalog/build.gradle
@@ -1,32 +1,22 @@
 plugins {
     id "org.jetbrains.kotlin.jvm"
     id "org.jetbrains.kotlin.kapt"
-    id "com.vanniktech.maven.publish"
     id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
-//
-//task relocateShadowJar(type: ConfigureShadowRelocation) {
-//    target = tasks.shadowJar
-//}
-//
-//shadowJar {
-//    dependencies {
-//        exclude(dependency('org.jetbrains.kotlin:.*'))
-//    }
-//    mergeServiceFiles()
-//}
-//
-//tasks.shadowJar.dependsOn tasks.relocateShadowJar
 
 dependencies {
-    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-toml:2.13.0'
+    implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-toml:2.13.3'
+    //noinspection GradlePackageUpdate keep 1.12.0 to stay on Kotlin 1.5.31 std lib
     implementation 'com.squareup.moshi:moshi:1.12.0'
+    //noinspection GradlePackageUpdate keep 1.12.0 to stay on Kotlin 1.5.31 std lib
     implementation ('com.squareup.moshi:moshi-kotlin:1.12.0') {
         exclude(group: "org.jetbrains.kotlin", module: "kotlin-reflect")
     }
+    //noinspection GradlePackageUpdate keep old version based on Gradle Kotlin runtime
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31"
 
-    kapt ("com.squareup.moshi:moshi-kotlin-codegen:1.12.0")
+    //noinspection GradlePackageUpdate keep 1.12.0 to stay on Kotlin 1.5.31 std lib
+    kapt ('com.squareup.moshi:moshi-kotlin-codegen:1.12.0')
 
     testImplementation 'junit:junit:4.13.2'
 }

--- a/catalog/build.gradle
+++ b/catalog/build.gradle
@@ -2,7 +2,21 @@ plugins {
     id "org.jetbrains.kotlin.jvm"
     id "org.jetbrains.kotlin.kapt"
     id "com.vanniktech.maven.publish"
+    id 'com.github.johnrengelman.shadow' version '7.1.2'
 }
+//
+//task relocateShadowJar(type: ConfigureShadowRelocation) {
+//    target = tasks.shadowJar
+//}
+//
+//shadowJar {
+//    dependencies {
+//        exclude(dependency('org.jetbrains.kotlin:.*'))
+//    }
+//    mergeServiceFiles()
+//}
+//
+//tasks.shadowJar.dependsOn tasks.relocateShadowJar
 
 dependencies {
     implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-toml:2.13.0'
@@ -10,6 +24,7 @@ dependencies {
     implementation ('com.squareup.moshi:moshi-kotlin:1.12.0') {
         exclude(group: "org.jetbrains.kotlin", module: "kotlin-reflect")
     }
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31"
 
     kapt ("com.squareup.moshi:moshi-kotlin-codegen:1.12.0")
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.caching=true
+kotlin.stdlib.default.dependency=false
 
 GROUP=nl.littlerobots.vcu
 VERSION_NAME=0.5.4-SNAPSHOT

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -1,7 +1,10 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ConfigureShadowRelocation
+
 plugins {
     id "org.jetbrains.kotlin.jvm"
     id 'java-gradle-plugin'
     id "com.vanniktech.maven.publish"
+    id 'com.github.johnrengelman.shadow'
 }
 
 gradlePlugin {
@@ -13,13 +16,38 @@ gradlePlugin {
     }
 }
 
+
+task relocateShadowJar(type: ConfigureShadowRelocation) {
+    target = tasks.shadowJar
+}
+
+shadowJar {
+    dependencies {
+        exclude(dependency('org.jetbrains.kotlin:.*'))
+    }
+    mergeServiceFiles()
+    // don't relocate these
+    relocate 'nl.littlerobots.vcu', 'nl.littlerobots.vcu'
+    relocate 'kotlin', 'kotlin'
+}
+
+tasks.shadowJar.dependsOn tasks.relocateShadowJar
+configurations.api.dependencies.remove dependencies.gradleApi()
+
 repositories {
     gradlePluginPortal()
 }
 
-dependencies {
-    implementation project(":catalog")
+// remove all runtime dependencies from publications; which is only the catalog module
+components.java.withVariantsFromConfiguration(configurations.runtimeElements) {
+    skip()
+}
 
+dependencies {
+    implementation project(path: ":catalog")
+    //noinspection GradlePackageUpdate
+    shadow "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.5.31"
+    shadow gradleApi()
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'com.github.ben-manes:gradle-versions-plugin:0.40.0'
     testImplementation(gradleTestKit())

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,6 +5,7 @@ pluginManagement {
         id "org.jetbrains.kotlin.kapt" version "1.5.31"
         id "com.diffplug.spotless" version "5.17.1"
         id "com.vanniktech.maven.publish" version "0.18.0"
+        id 'com.github.johnrengelman.shadow' version '7.1.2'
     }
 
     dependencyResolutionManagement {


### PR DESCRIPTION
This should fix #39, relocating Jackson and other 3rd parties in to the main plugin jar.