### PR TITLE
Apply VersionCatalogUpdatePlugin on rootProject only

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,10 @@
 name: build & test
 
-on: push
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build-test:

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-rc-1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdatePlugin.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdatePlugin.kt
@@ -35,7 +35,7 @@ class VersionCatalogUpdatePlugin : Plugin<Project> {
         }
 
         if (project != project.rootProject) {
-            throw IllegalStateException("Should be applied to the root project only")
+            return
         }
 
         val extension = project.extensions.create(EXTENSION_NAME, VersionCatalogUpdateExtension::class.java)


### PR DESCRIPTION
For https://github.com/littlerobots/version-catalog-update-plugin/issues/66#issuecomment-1212223577, And if you approve this, should we note the usage in a Gradle init script in README?