### PR TITLE
Add interactive mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
-Version 0.5.4
+Version 0.6.0
 -------------
+* New feature: `--incremental` command line option to stage changes without updating the TOML file [(#63)](https://github.com/littlerobots/version-catalog-update-plugin/issues/63)
 * Shadow (bundle) dependencies to prevent conflicts with other plugins [(#39)](https://github.com/littlerobots/version-catalog-update-plugin/issues/39)
+* Fix an issue with unused kept pinned dependencies causing the update task to fail [(#61)](https://github.com/littlerobots/version-catalog-update-plugin/issues/61)
+* Removed `--add` option. [(#69)](https://github.com/littlerobots/version-catalog-update-plugin/issues/69)
 
 Version 0.5.3
 -------------

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ in the version catalog file will be considered unused. This is [configurable](#c
 
 ### Interactive mode
 Updating all dependencies at once is without testing is generally not recommended. When using a version control system, changes to the version catalog can be rolled back
-by comparing diff, but for large updates this may be inconvenient. In these cases, interactive mode might help.
+by comparing a diff, but for large updates this may be inconvenient. In these cases, interactive mode might help.
 
 When running `./gradlew versionCatalogUpdate --interactive` the `libs.versions.toml` file will not be directly be updated, in stead
 a `libs.versions.updates.toml` file will be created containing the entries that would be updated and any pinned entries

--- a/README.md
+++ b/README.md
@@ -60,6 +60,49 @@ To update the catalog file at any time run `./gradlew versionCatalogUpdate`. Thi
 No new entries will be added to the catalog, but unused entries will be removed. Any dependency that is not reported by the versions plugin, but still appears
 in the version catalog file will be considered unused. This is [configurable](#configuration).
 
+### Interactive mode
+Updating all dependencies at once is without testing is generally not recommended. When using a version control system, changes to the version catalog can be rolled back
+by comparing diff, but for large updates this may be inconvenient. In these cases, interactive mode might help.
+
+When running `./gradlew versionCatalogUpdate --interactive` the `libs.versions.toml` file will not be directly be updated, in stead
+a `libs.versions.updates.toml` file will be created containing the entries that would be updated and any pinned entries
+that can be updated. This file uses the short form dependency notation without any `version.ref`s. Pinned entries are commented
+by default, all other entries are uncommented. To skip updating an entry in the TOML file it can be commented out or removed completely.
+It's also possible to edit the entry if that's desired.
+
+To apply the changes to the `libs.versions.toml` file, run `./gradlew versionCatalogApplyUpdates`. This will also
+update `version.ref`s and `versions` in the same way as `versionCatalogUpdate` would.
+
+Note that any comments and any other TOML tables than `[libraries]` and `[plugins]` will be ignored when applying the changes.
+
+<details>
+<summary>Example libs.versions.updates.toml</summary>
+
+```
+# Version catalog updates generated at 2022-08-19T16:00:29.757349
+#
+# Contents of this file will be applied to libs.versions.toml when running versionCatalogApplyUpdates.
+#
+# Comments will not be applied to the version catalog when updating.
+# To prevent a version upgrade, comment out the entry or remove it.
+#
+[libraries]
+# @pinned version 4.9.3 (antlr) --> 4.10.1
+#antlr = "org.antlr:antlr4:4.10.1"
+# From version 2.5.4 (asciidoctorj) --> 2.5.5
+asciidoctorj = "org.asciidoctor:asciidoctorj:2.5.5"
+# From version 2.1.2 (asciidoctorjPdf) --> 2.1.6
+asciidoctorjPdf = "org.asciidoctor:asciidoctorj-pdf:2.1.6"
+
+[plugins]
+# Updated from version 1.20.0
+detekt = "io.gitlab.arturbosch.detekt:1.21.0"
+# Updated from version 1.7.0
+dokka = "org.jetbrains.dokka:1.7.10"
+```
+
+</details>
+
 ### Formatting only
 To format the existing `libs.versions.toml` file without updating library versions, you can run `./gradlew versionCatalogFormat`.
 This will format the version catalog and create new version references, just like the `versionCatalogUpdate` task would do.

--- a/catalog/src/main/kotlin/nl/littlerobots/vcu/VersionCatalogWriter.kt
+++ b/catalog/src/main/kotlin/nl/littlerobots/vcu/VersionCatalogWriter.kt
@@ -15,6 +15,7 @@
 */
 package nl.littlerobots.vcu
 
+import nl.littlerobots.vcu.model.HasVersion
 import nl.littlerobots.vcu.model.Library
 import nl.littlerobots.vcu.model.Plugin
 import nl.littlerobots.vcu.model.VersionCatalog
@@ -25,7 +26,7 @@ import java.io.Writer
 private const val BUNDLE_INDENT = 4
 
 class VersionCatalogWriter {
-    fun write(versionCatalog: VersionCatalog, writer: Writer) {
+    fun write(versionCatalog: VersionCatalog, writer: Writer, commentEntry: (HasVersion) -> Boolean = { false }) {
         val printWriter = PrintWriter(writer)
         if (versionCatalog.versions.isNotEmpty()) {
             for (line in versionCatalog.versionComments.tableComments) {
@@ -50,6 +51,9 @@ class VersionCatalogWriter {
             for (library in versionCatalog.libraries) {
                 for (comment in versionCatalog.libraryComments.getCommentsForKey(library.key)) {
                     printWriter.println(comment)
+                }
+                if (commentEntry(library.value)) {
+                    printWriter.print("#")
                 }
                 printWriter.println("""${library.key} = ${formatLibrary(library.value)}""")
             }
@@ -90,6 +94,9 @@ class VersionCatalogWriter {
                 for (comment in versionCatalog.pluginComments.getCommentsForKey(plugin.key)) {
                     printWriter.println(comment)
                 }
+                if (commentEntry(plugin.value)) {
+                    printWriter.print("#")
+                }
                 printWriter.println("${plugin.key} = ${formatPlugin(plugin.value)}")
             }
         }
@@ -111,6 +118,7 @@ class VersionCatalogWriter {
                 append(" } }")
             }.toString()
         }
+
         is VersionDefinition.Unspecified -> "{ id = \"${plugin.id}\" }"
     }
 
@@ -132,6 +140,7 @@ class VersionCatalogWriter {
                 append(" } }")
             }.toString()
         }
+
         is VersionDefinition.Unspecified -> "{ module = \"${library.module}\" }"
     }
 
@@ -142,6 +151,7 @@ class VersionCatalogWriter {
                 "${it.key} = \"${it.value}\""
             }
         }
+
         else -> throw IllegalStateException("Invalid version definition $versionDefinition")
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.caching=true
 kotlin.stdlib.default.dependency=false
 
 GROUP=nl.littlerobots.vcu
-VERSION_NAME=0.5.4-SNAPSHOT
+VERSION_NAME=0.5.5-SNAPSHOT
 
 POM_NAME=Version catalog updates plugin
 POM_DESCRIPTION=A gradle plugin that updates the version catalog file

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.caching=true
 kotlin.stdlib.default.dependency=false
 
 GROUP=nl.littlerobots.vcu
-VERSION_NAME=0.5.5-SNAPSHOT
+VERSION_NAME=0.6.0-SNAPSHOT
 
 POM_NAME=Version catalog updates plugin
 POM_DESCRIPTION=A gradle plugin that updates the version catalog file

--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogApplyUpdatesTask.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogApplyUpdatesTask.kt
@@ -1,0 +1,92 @@
+/*
+* Copyright 2021 Hugo Visser
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package nl.littlerobots.vcu.plugin
+
+import nl.littlerobots.vcu.VersionCatalogParser
+import nl.littlerobots.vcu.VersionCatalogWriter
+import nl.littlerobots.vcu.model.resolveVersions
+import nl.littlerobots.vcu.model.sortKeys
+import nl.littlerobots.vcu.model.updateFrom
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
+
+abstract class VersionCatalogApplyUpdatesTask : DefaultTask() {
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.RELATIVE)
+    abstract val catalogFile: RegularFileProperty
+
+    @get:Input
+    @get:Optional
+    abstract val sortByKey: Property<Boolean>
+
+    @get:Internal
+    abstract val keep: Property<KeepConfigurationInput>
+
+    private val keepRefs by lazy {
+        keep.orNull?.getVersionCatalogRefs() ?: emptySet()
+    }
+
+    @TaskAction
+    fun applyUpdates() {
+        val updatesFile = catalogFile.asFile.get().updatesFile
+        val versionCatalogParser = VersionCatalogParser()
+        if (updatesFile.exists()) {
+            val catalog = catalogFile.asFile.get().inputStream().use {
+                versionCatalogParser.parse(it)
+            }
+            val updates = updatesFile.inputStream().use {
+                versionCatalogParser.parse(it)
+            }
+            if (updates.libraries.isEmpty() && updates.plugins.isEmpty()) {
+                updatesFile.delete()
+                return
+            }
+
+            // reconstruct an update from the current catalog + the updates, as if manually edited
+            val fullUpdate = catalog.resolveVersions()
+                .copy(versions = emptyMap(), bundles = emptyMap())
+                .updateFrom(updates, purge = false)
+                // undo any version grouping
+                .resolveVersions()
+                .copy(versions = emptyMap())
+
+            val updatedCatalog = catalog.updateFrom(fullUpdate, addNew = false, purge = false)
+                .withKeepUnusedVersions(catalog, keep.orNull?.keepUnusedVersions?.getOrElse(false) ?: false)
+                .withKeptVersions(catalog, keepRefs)
+                .let {
+                    if (sortByKey.getOrElse(true)) {
+                        it.sortKeys()
+                    } else {
+                        it
+                    }
+                }
+            VersionCatalogWriter().write(updatedCatalog, catalogFile.get().asFile.writer())
+            updatesFile.delete()
+        }
+    }
+
+    companion object {
+        const val TASK_NAME = "versionCatalogApplyUpdates"
+    }
+}

--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdatePlugin.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdatePlugin.kt
@@ -44,6 +44,7 @@ class VersionCatalogUpdatePlugin : Plugin<Project> {
 
         val catalogUpdatesTask = project.tasks.register(UPDATE_TASK_NAME, VersionCatalogUpdateTask::class.java)
         val catalogFormatTask = project.tasks.register(FORMAT_TASK_NAME, VersionCatalogFormatTask::class.java)
+        val catalogApplyUpdatesTask = project.tasks.register(VersionCatalogApplyUpdatesTask.TASK_NAME, VersionCatalogApplyUpdatesTask::class.java)
 
         catalogUpdatesTask.configure { task ->
             task.reportJson.set(reportJson)
@@ -57,6 +58,15 @@ class VersionCatalogUpdatePlugin : Plugin<Project> {
         }
 
         catalogFormatTask.configure { task ->
+            task.sortByKey.set(extension.sortByKey)
+            task.keep.set(project.objects.newInstance(KeepConfigurationInput::class.java, extension.keep))
+
+            if (!task.catalogFile.isPresent) {
+                task.catalogFile.set(project.rootProject.file("gradle/libs.versions.toml"))
+            }
+        }
+
+        catalogApplyUpdatesTask.configure { task ->
             task.sortByKey.set(extension.sortByKey)
             task.keep.set(project.objects.newInstance(KeepConfigurationInput::class.java, extension.keep))
 

--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateTask.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateTask.kt
@@ -37,7 +37,6 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.file.RegularFileProperty
-import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
@@ -53,11 +52,10 @@ import java.io.File
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 import java.util.jar.JarFile
-import javax.inject.Inject
 
 private const val PROPERTIES_SUFFIX = ".properties"
 
-abstract class VersionCatalogUpdateTask @Inject constructor(private val objectFactory: ObjectFactory) : DefaultTask() {
+abstract class VersionCatalogUpdateTask : DefaultTask() {
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFile
     abstract val reportJson: RegularFileProperty

--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateTask.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateTask.kt
@@ -17,6 +17,8 @@ package nl.littlerobots.vcu.plugin
 
 import nl.littlerobots.vcu.VersionCatalogParser
 import nl.littlerobots.vcu.VersionCatalogWriter
+import nl.littlerobots.vcu.model.Comments
+import nl.littlerobots.vcu.model.HasVersion
 import nl.littlerobots.vcu.model.Library
 import nl.littlerobots.vcu.model.Plugin
 import nl.littlerobots.vcu.model.VersionCatalog
@@ -35,6 +37,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.artifacts.ResolvedArtifact
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFile
@@ -47,12 +50,14 @@ import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
 import org.gradle.internal.component.external.model.ModuleComponentArtifactIdentifier
 import java.io.File
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import java.util.jar.JarFile
 import javax.inject.Inject
 
 private const val PROPERTIES_SUFFIX = ".properties"
 
-abstract class VersionCatalogUpdateTask @Inject constructor() : DefaultTask() {
+abstract class VersionCatalogUpdateTask @Inject constructor(private val objectFactory: ObjectFactory) : DefaultTask() {
     @get:PathSensitive(PathSensitivity.RELATIVE)
     @get:InputFile
     abstract val reportJson: RegularFileProperty
@@ -64,6 +69,10 @@ abstract class VersionCatalogUpdateTask @Inject constructor() : DefaultTask() {
     @set:Option(option = "create", description = "Create libs.versions.toml based on current dependencies")
     @get:Internal
     abstract var createCatalog: Boolean
+
+    @set:Option(option = "interactive", description = "Stage changes before applying to the toml file")
+    @get:Internal
+    abstract var interactive: Boolean
 
     @get:Input
     abstract val pins: Property<PinsConfigurationInput>
@@ -91,6 +100,12 @@ abstract class VersionCatalogUpdateTask @Inject constructor() : DefaultTask() {
         val versionsReportResult =
             reportParser.generateCatalog(reportJson.get().asFile.inputStream(), useLatestVersions = !createCatalog)
         val catalogFromDependencies = versionsReportResult.catalog
+
+        if (interactive && createCatalog) {
+            throw GradleException("--interactive cannot be used with --create")
+        }
+
+        checkInteractiveState()
 
         val currentCatalog = if (catalogFile.get().exists()) {
             if (createCatalog) {
@@ -135,9 +150,6 @@ abstract class VersionCatalogUpdateTask @Inject constructor() : DefaultTask() {
                 }
             }
 
-        val writer = VersionCatalogWriter()
-        writer.write(updatedCatalog, catalogFile.get().writer())
-
         if (versionsReportResult.exceeded.isNotEmpty() && !createCatalog) {
             emitExceededWarning(versionsReportResult.exceeded, currentCatalog)
         }
@@ -145,6 +157,170 @@ abstract class VersionCatalogUpdateTask @Inject constructor() : DefaultTask() {
         checkForUpdatesForLibrariesWithVersionCondition(updatedCatalog, versionsReportResult.outdated)
         checkForUpdatedPinnedLibraries(updatedCatalog, catalogWithResolvedPlugins, pins)
         checkForUpdatedPinnedPlugins(updatedCatalog, catalogWithResolvedPlugins, pins)
+
+        if (interactive) {
+            writeUpdatesFile(
+                currentCatalog,
+                updatedCatalog,
+                getPinsWithUpdatedVersions(catalogWithResolvedPlugins, pins)
+            )
+            if (keep.orNull?.keepUnusedVersions?.getOrElse(false) == false) {
+                // remove entries that are no longer in the update
+                val c = currentCatalog.copy(
+                    libraries = currentCatalog.libraries.filterValues { library ->
+                        updatedCatalog.libraries.values.any {
+                            it.group == library.group
+                        }
+                    },
+                    plugins = currentCatalog.plugins.filterValues { plugin ->
+                        updatedCatalog.plugins.values.any {
+                            it.id == plugin.id
+                        }
+                    }
+                )
+                // update again to fix bundles and versions
+                val currentPruned = currentCatalog.updateFrom(c, purge = true)
+                val writer = VersionCatalogWriter()
+                // write out the current catalog without sorting it
+                writer.write(currentPruned, catalogFile.get().writer())
+            }
+        } else {
+            val writer = VersionCatalogWriter()
+            writer.write(updatedCatalog, catalogFile.get().writer())
+        }
+    }
+
+    /**
+     * Write a version catalog diff file
+     * @param currentCatalog the version catalog before updates
+     * @param updatedCatalog the version catalog updated, considering pins & keeps etc,
+     * @param pins the pins holding the _updated_ version from [getPinsWithUpdatedVersions]
+     */
+    private fun writeUpdatesFile(currentCatalog: VersionCatalog, updatedCatalog: VersionCatalog, pins: Pins) {
+        val currentResolved = currentCatalog.resolveVersions()
+        // the update as if the pins are reverted, e.g. all possible updates
+        val updatedResolved = updatedCatalog
+            .updateFrom(updatedCatalog.withPins(pins), purge = false)
+            .resolveVersions()
+        val catalogFile = this.catalogFile.get()
+
+        val diff = updatedResolved.copy(
+            libraries = updatedResolved.libraries.filterNot { entry ->
+                currentResolved.libraries.values.contains(entry.value)
+            },
+            plugins = updatedResolved.plugins.filterNot { entry ->
+                currentResolved.plugins.values.contains(entry.value)
+            },
+            bundles = emptyMap(), versions = emptyMap()
+        )
+
+        if (diff.plugins.isEmpty() && diff.libraries.isEmpty() && pins.libraries.isEmpty() && pins.plugins.isEmpty()) {
+            project.logger.warn("There are no updates available")
+            return
+        }
+
+        val tableComments = """
+                    # Version catalog updates generated at ${
+        LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        }
+                    #
+                    # Contents of this file will be applied to ${catalogFile.name} when running ${VersionCatalogApplyUpdatesTask.TASK_NAME}.
+                    #
+                    # Comments will not be applied to the version catalog when updating.
+                    # To prevent a version upgrade, comment out the entry or remove it.
+                    #
+        """.trimIndent().lines()
+
+        fun getUpdateComment(dependencyEntry: Map.Entry<String, HasVersion>, dependenciesMap: Map<String, HasVersion>): List<String> {
+            val previousVersion = (dependenciesMap[dependencyEntry.key]?.version as? VersionDefinition.Simple)?.version
+            return previousVersion?.let { version ->
+                dependenciesMap[dependencyEntry.key]?.version?.let { versionDefinition ->
+                    val currentVersionGroup = if (versionDefinition is VersionDefinition.Reference) {
+                        " (${versionDefinition.ref})"
+                    } else {
+                        ""
+                    }
+                    val matchingPin = when (val dependency = dependencyEntry.value) {
+                        is Library -> pins.libraries.firstOrNull { it.group == dependency.group }
+                        is Plugin -> pins.plugins.firstOrNull { it.id == dependency.id }
+                        else -> error("Unexpected dependency type ${dependency.javaClass.name}")
+                    }
+                    val updatedVersion = (dependencyEntry.value.version as VersionDefinition.Simple).version
+                    if (matchingPin != null) {
+                        listOf("# @pinned version $version$currentVersionGroup --> $updatedVersion")
+                    } else {
+                        listOf("# From version $version$currentVersionGroup --> $updatedVersion")
+                    }
+                }
+            } ?: emptyList()
+        }
+
+        val diffWithComments = diff.copy(
+            libraryComments = Comments(
+                tableComments = tableComments,
+                entryComments = diff.libraries.map { entry ->
+                    entry.key to getUpdateComment(entry, currentResolved.libraries)
+                }.toMap()
+            ),
+            pluginComments = Comments(
+                tableComments = if (diff.libraries.isEmpty()) tableComments else emptyList(),
+                entryComments = diff.plugins.map { entry ->
+                    entry.key to getUpdateComment(entry, currentResolved.plugins)
+                }.toMap()
+            )
+        )
+
+        val updateFile = catalogFile.updatesFile
+
+        val writer = VersionCatalogWriter()
+        updateFile.writer().use { outputStreamWriter ->
+            writer.write(diffWithComments, outputStreamWriter) { versioned ->
+                when (versioned) {
+                    is Library -> pins.libraries.any { it.group == versioned.group }
+                    is Plugin -> pins.plugins.any { it.id == versioned.id }
+                    else -> false
+                }
+            }
+        }
+        project.logger.warn("Updates are written to ${updateFile.name}. Run the ${VersionCatalogApplyUpdatesTask.TASK_NAME} task to apply updates to ${catalogFile.name}")
+    }
+
+    private fun checkInteractiveState() {
+        val updateFile = catalogFile.orNull?.updatesFile
+        if (updateFile?.exists() == true) {
+            throw GradleException("${updateFile.absolutePath} exists, did you mean to run the ${VersionCatalogApplyUpdatesTask.TASK_NAME} task to apply the updates?")
+        }
+    }
+
+    /**
+     * Return pins that can be updated
+     * @param catalog the version catalog to use as a source for library and plugin updates
+     * @param pins the pins based on the current version in the version catalog
+     */
+    private fun getPinsWithUpdatedVersions(catalog: VersionCatalog, pins: Pins): Pins {
+        return Pins(
+            libraries = pins.libraries
+                .filter { pinned ->
+                    catalog.libraries.values.filter {
+                        it.version is VersionDefinition.Simple
+                    }.any {
+                        it.group == pinned.group && it.version != pinned.version
+                    }
+                }.map { pinned ->
+                    catalog.libraries.values.first { it.group == pinned.group }
+                }.toSet(),
+            plugins = pins.plugins.filter { pinned ->
+                catalog.plugins.values.filter {
+                    it.version is VersionDefinition.Simple
+                }.any {
+                    it.id == pinned.id && it.version != pinned.version
+                }
+            }.map { pinned ->
+                catalog.plugins.values.first {
+                    it.id == pinned.id
+                }
+            }.toSet()
+        )
     }
 
     /**
@@ -552,3 +728,6 @@ private fun MutableMap<String, Library>.removeLibraries(libs: Collection<Library
         }
     }
 }
+
+val File.updatesFile: File
+    get() = File(parentFile, "$nameWithoutExtension.updates.$extension")

--- a/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogApplyChangesTest.kt
+++ b/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogApplyChangesTest.kt
@@ -1,0 +1,102 @@
+/*
+* Copyright 2021 Hugo Visser
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package nl.littlerobots.vcu.plugin
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class VersionCatalogApplyChangesTest {
+    @get:Rule
+    val tempDir = TemporaryFolder()
+    lateinit var buildFile: File
+
+    @Before
+    fun setup() {
+        buildFile = tempDir.newFile("build.gradle")
+    }
+
+    @Test
+    fun `changes are applied to the version catalog`() {
+        val reportJson = tempDir.newFile()
+
+        buildFile.writeText(
+            """
+            plugins {
+                id "nl.littlerobots.version-catalog-update"
+            }
+
+            tasks.named("versionCatalogUpdate").configure {
+                it.reportJson = file("${reportJson.name}")
+            }
+            """.trimIndent()
+        )
+
+        val toml = """
+            [versions]
+            coil = "1.0.0"
+
+            [libraries]
+            test = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+
+            [plugins]
+            vcu = "nl.littlerobots.version-catalog-update:1.0"
+        """.trimIndent()
+
+        val staged = """
+            [libraries]
+            test = "io.coil-kt:coil-compose:2.0.0"
+
+            [plugins]
+            #vcu = "nl.littlerobots.version-catalog-update:1.0"
+        """.trimIndent()
+
+        val tomlFile = File(tempDir.root, "gradle/libs.versions.toml")
+        val stagingFile = File(tempDir.root, "gradle/libs.versions.updates.toml")
+
+        File(tempDir.root, "gradle").mkdir()
+        tomlFile.writeText(toml)
+        stagingFile.writeText(staged)
+
+        GradleRunner.create()
+            .withProjectDir(tempDir.root)
+            .withArguments(VersionCatalogApplyUpdatesTask.TASK_NAME)
+            .withPluginClasspath()
+            .build()
+
+        assertFalse(stagingFile.exists())
+        // keeps version group and updates it, skips vcu due to comment
+        assertEquals(
+            """
+            [versions]
+            coil = "2.0.0"
+
+            [libraries]
+            test = { module = "io.coil-kt:coil-compose", version.ref = "coil" }
+
+            [plugins]
+            vcu = "nl.littlerobots.version-catalog-update:1.0"
+
+            """.trimIndent(),
+            tomlFile.readText()
+        )
+    }
+}


### PR DESCRIPTION
Support the `--interactive` command line option to versionCatalogUpdate. In this mode, updates are not written to the TOML file, but staged in a `<name of toml>.updates.toml` file. This file can then be inspected and edited to specify what updates to apply when the versionCatalogApplyChanges task is run.

Fixes #63 
