### PR TITLE
Filter transitive dependencies reported as current from versions report

### DIFF
--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateTask.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateTask.kt
@@ -93,12 +93,6 @@ abstract class VersionCatalogUpdateTask : DefaultTask() {
 
     @TaskAction
     fun updateCatalog() {
-        val reportParser = VersionReportParser()
-
-        val versionsReportResult =
-            reportParser.generateCatalog(reportJson.get().asFile.inputStream(), useLatestVersions = !createCatalog)
-        val catalogFromDependencies = versionsReportResult.catalog
-
         if (interactive && createCatalog) {
             throw GradleException("--interactive cannot be used with --create")
         }
@@ -118,6 +112,11 @@ abstract class VersionCatalogUpdateTask : DefaultTask() {
                 throw GradleException("${catalogFile.get()} does not exist. Did you mean to specify the --create option?")
             }
         }
+
+        val reportParser = VersionReportParser()
+        val versionsReportResult =
+            reportParser.generateCatalog(reportJson.get().asFile.inputStream(), currentCatalog, useLatestVersions = !createCatalog)
+        val catalogFromDependencies = versionsReportResult.catalog
 
         val pins = getPins(currentCatalog, pinRefs + getPinnedRefsFromComments(currentCatalog))
         val keepRefs = this.keepRefs + getKeepRefsFromComments(currentCatalog)


### PR DESCRIPTION
If a version is reported as current, but the version is different from the version catalog, consider that version to be transitive, and remove it from the catalog that is generated from the versions report.

This fixes the issue where a version is downgraded because it's not used but declared in the catalog, possibly breaking version references etc in the process.

Fixes #71 