### PR TITLE
Add dsl to configure additional toml files

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,6 +264,49 @@ kotlin = "1.6.10"
 my-library = "com.example.library:1.0"
 ```
 
+## Managing additional version catalogs
+The default tasks operate on the default version catalog file, `libs.versions.toml` in the `gradle` directory
+of a project. Additional version catalogs can be configured within the `versionCatalogUpdate` extension:
+
+<details open>
+<summary>build.gradle</summary>
+
+```groovy
+versionCatalogUpdate {
+    // These options will be set as default for all version catalogs
+    sortByKey = true
+    // Referenced that are pinned are not automatically updated.
+    // They are also not automatically kept however (use keep for that).
+    pin {
+        ...
+    }
+    keep {
+        ...
+    }
+    versionCatalogs {
+        myOtherCatalog {
+            catalogFile = file("catalogs/mycatalog.versions.toml")
+            // not sorted
+            sortByKey = false
+        }
+        special {
+            catalogFile = file("catalogs/special.versions.toml")
+            // overrides the options set above
+            keep {
+                keepUnusedVersions = true
+            }
+        }
+    }
+}
+```
+</details>
+
+By configuring additional version catalogs, new tasks in the form of `versionCatalogUpdate<Name>` will get added.
+For example, when declaring a `myOtherCatalog` catalog, the tasks `versionCatalogUpdateMyOtherCatalog`, `versionCatalogFormatMyotherCatalog`
+and `versionCatalogAppyUpdatesMyOtherCatalog` are configured. These work the same as the default tasks
+and have the same available options. Each version catalog definition can specify configuration for
+`sortByKey` and the `pin` and `keep` blocks. If not defined, the default options will be applied for those options.
+
 ## Snapshot versions
 For snapshots versions add the Sonatype snapshot repository `https://oss.sonatype.org/content/repositories/snapshots/`.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.caching=true
 kotlin.stdlib.default.dependency=false
 
 GROUP=nl.littlerobots.vcu
-VERSION_NAME=0.6.2-SNAPSHOT
+VERSION_NAME=0.7.0-SNAPSHOT
 
 POM_NAME=Version catalog updates plugin
 POM_DESCRIPTION=A gradle plugin that updates the version catalog file

--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateExtension.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateExtension.kt
@@ -18,9 +18,11 @@
 package nl.littlerobots.vcu.plugin
 
 import org.gradle.api.Action
+import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.artifacts.MinimalExternalModuleDependency
 import org.gradle.api.artifacts.ModuleIdentifier
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.provider.SetProperty
@@ -28,6 +30,7 @@ import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 import org.gradle.plugin.use.PluginDependency
 import java.io.Serializable
+import javax.inject.Inject
 
 abstract class VersionCatalogUpdateExtension {
     @get:Optional
@@ -39,6 +42,9 @@ abstract class VersionCatalogUpdateExtension {
     @get:Nested
     abstract val keep: KeepConfiguration
 
+    @get:Nested
+    abstract val versionCatalogs: NamedDomainObjectContainer<VersionCatalogConfig>
+
     fun pin(action: Action<PinConfiguration>) {
         action.execute(pins)
     }
@@ -46,14 +52,29 @@ abstract class VersionCatalogUpdateExtension {
     fun keep(action: Action<KeepConfiguration>) {
         action.execute(keep)
     }
+
+    fun versionCatalogs(action: Action<NamedDomainObjectContainer<VersionCatalogConfig>>) {
+        action.execute(versionCatalogs)
+    }
 }
 
-@Suppress("LeakingThis")
 abstract class VersionRefConfiguration : Serializable {
     abstract val versions: SetProperty<String>
     abstract val libraries: SetProperty<Provider<MinimalExternalModuleDependency>>
     abstract val plugins: SetProperty<Provider<PluginDependency>>
     abstract val groups: SetProperty<String>
+}
+
+abstract class VersionCatalogConfig @Inject constructor(val name: String) {
+    abstract val catalogFile: RegularFileProperty
+    @get:Optional
+    abstract val sortByKey: Property<Boolean>
+
+    @get:Nested
+    abstract val pins: PinConfiguration
+
+    @get:Nested
+    abstract val keep: KeepConfiguration
 }
 
 abstract class PinConfiguration : VersionRefConfiguration()

--- a/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogFormatPluginTest.kt
+++ b/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogFormatPluginTest.kt
@@ -197,6 +197,7 @@ class VersionCatalogFormatPluginTest {
             .withProjectDir(tempDir.root)
             .withArguments("versionCatalogFormat")
             .withPluginClasspath()
+            .withDebug(true)
             .build()
 
         val libs = File(tempDir.root, "gradle/libs.versions.toml").readText()

--- a/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogPluginTest.kt
+++ b/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogPluginTest.kt
@@ -1,0 +1,79 @@
+/*
+* Copyright 2021 Hugo Visser
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+* http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package nl.littlerobots.vcu.plugin
+
+import org.gradle.testkit.runner.GradleRunner
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import java.io.File
+
+class VersionCatalogPluginTest {
+    @get:Rule
+    val tempDir = TemporaryFolder()
+    lateinit var buildFile: File
+
+    @Before
+    fun setup() {
+        buildFile = tempDir.newFile("build.gradle")
+    }
+
+    @Test
+    fun `versionCatalogs block creates task for each catalog`() {
+        val reportJson = tempDir.newFile()
+
+        buildFile.writeText(
+            """
+            plugins {
+                id "nl.littlerobots.version-catalog-update"
+            }
+
+            tasks.named("versionCatalogUpdate").configure {
+                it.reportJson = file("${reportJson.name}")
+            }
+
+            versionCatalogUpdate {
+                versionCatalogs {
+                    libs2 {
+                        catalogFile = file("libs2.versions.toml")
+                    }
+                }
+            }
+            // Workaround for classpath issues with applying the dependency versions plugin in tests
+            // With report path set, the dependency is not required
+            tasks.named("versionCatalogUpdateLibs2").configure {
+                it.reportJson = file("${reportJson.name}")
+            }
+            """.trimIndent()
+
+        )
+
+        val result = GradleRunner.create()
+            .withProjectDir(tempDir.root)
+            .withArguments("tasks")
+            .withPluginClasspath()
+            .build()
+
+        assertTrue(result.output.contains("versionCatalogUpdate"))
+        assertTrue(result.output.contains("versionCatalogFormat"))
+        assertTrue(result.output.contains("versionCatalogApply"))
+        assertTrue(result.output.contains("versionCatalogUpdateLibs2"))
+        assertTrue(result.output.contains("versionCatalogFormatLibs2"))
+        assertTrue(result.output.contains("versionCatalogApplyUpdatesLibs2"))
+    }
+}


### PR DESCRIPTION
Adds `versionCatalogs` container to extension to configure additional versionCatalog* tasks

Fixes #52 