### PR TITLE
Override the default toml file

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,12 +300,67 @@ versionCatalogUpdate {
 }
 ```
 </details>
+<details>
+<summary>build.gradle.kts</summary>
+
+```kotlin
+versionCatalogUpdate {
+    // These options will be set as default for all version catalogs
+    sortByKey.set(true)
+    // Referenced that are pinned are not automatically updated.
+    // They are also not automatically kept however (use keep for that).
+    pin {
+        ...
+    }
+    keep {
+        ...
+    }
+    versionCatalogs {
+        create("myOtherCatalog") {
+            catalogFile.set(file("catalogs/mycatalog.versions.toml"))
+            // not sorted
+            sortByKey.set(false)
+        }
+        create("special") {
+            catalogFile.set)file("catalogs/special.versions.toml"))
+            // overrides the options set above
+            keep {
+                keepUnusedVersions.set(true)
+            }
+        }
+    }
+}
+```
+</details>
 
 By configuring additional version catalogs, new tasks in the form of `versionCatalogUpdate<Name>` will get added.
 For example, when declaring a `myOtherCatalog` catalog, the tasks `versionCatalogUpdateMyOtherCatalog`, `versionCatalogFormatMyotherCatalog`
 and `versionCatalogAppyUpdatesMyOtherCatalog` are configured. These work the same as the default tasks
 and have the same available options. Each version catalog definition can specify configuration for
 `sortByKey` and the `pin` and `keep` blocks. If not defined, the default options will be applied for those options.
+
+### Changing the default version catalog
+By the default the plugin uses `gradle/libs.versions.toml` as the primary version catalog file.
+To change the default, configure it in the `versionCatalogUpdate` block:
+
+<details open>
+<summary>build.gradle</summary>
+
+```groovy
+versionCatalogUpdate {
+    catalogFile = file("path/to/the/catalog.toml")
+}
+```
+</details>
+<details open>
+<summary>build.gradle.kts</summary>
+
+```kotlin
+versionCatalogUpdate {
+    catalogFile.set(file("path/to/the/catalog.toml"))
+}
+```
+</details>
 
 ## Snapshot versions
 For snapshots versions add the Sonatype snapshot repository `https://oss.sonatype.org/content/repositories/snapshots/`.

--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateExtension.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateExtension.kt
@@ -36,6 +36,9 @@ abstract class VersionCatalogUpdateExtension {
     @get:Optional
     abstract val sortByKey: Property<Boolean>
 
+    @get:Optional
+    abstract val catalogFile: RegularFileProperty
+
     @get:Nested
     abstract val pins: PinConfiguration
 

--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdatePlugin.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdatePlugin.kt
@@ -44,7 +44,10 @@ class VersionCatalogUpdatePlugin : Plugin<Project> {
 
         val defaultVersionCatalog = project.objects.newInstance(VersionCatalogConfig::class.java, "")
             .applyDefaultSettings(extension)
-        defaultVersionCatalog.catalogFile.set(project.rootProject.file("gradle/libs.versions.toml"))
+
+        defaultVersionCatalog.catalogFile.set(
+            extension.catalogFile.convention(project.layout.projectDirectory.file("gradle/libs.versions.toml"))
+        )
 
         configureTasks(project, defaultVersionCatalog, reportJson)
 


### PR DESCRIPTION
Adds a `catalogFile` property on the `versionCatalogUpdate` extension to override the default version catalog used for the default tasks.

Fixes #92 