### PR TITLE
Keep version catalog table order

### DIFF
--- a/catalog/src/main/kotlin/nl/littlerobots/vcu/VersionCatalogParser.kt
+++ b/catalog/src/main/kotlin/nl/littlerobots/vcu/VersionCatalogParser.kt
@@ -21,16 +21,17 @@ import nl.littlerobots.vcu.model.Library
 import nl.littlerobots.vcu.model.Plugin
 import nl.littlerobots.vcu.model.VersionCatalog
 import nl.littlerobots.vcu.model.VersionDefinition
+import nl.littlerobots.vcu.toml.DEFAULT_TABLE_ORDER
+import nl.littlerobots.vcu.toml.TABLE_BUNDLES
+import nl.littlerobots.vcu.toml.TABLE_LIBRARIES
+import nl.littlerobots.vcu.toml.TABLE_PLUGINS
+import nl.littlerobots.vcu.toml.TABLE_VERSIONS
 import java.io.BufferedReader
 import java.io.InputStream
 import java.io.StringReader
 
 private val TABLE_REGEX = Regex("\\[\\s?(versions|libraries|bundles|plugins)\\s?].*")
 private val KEY_REGEX = Regex("^(.*?)=.*")
-private const val TABLE_VERSIONS = "versions"
-private const val TABLE_LIBRARIES = "libraries"
-private const val TABLE_BUNDLES = "bundles"
-private const val TABLE_PLUGINS = "plugins"
 
 class VersionCatalogParser {
 
@@ -46,8 +47,22 @@ class VersionCatalogParser {
         val libraries = catalog.getTable(TABLE_LIBRARIES)?.toDependencyMap() ?: emptyMap()
         val bundles = catalog.getTable(TABLE_BUNDLES)?.toTypedMap<List<String>>() ?: emptyMap()
         val plugins = catalog.getTable(TABLE_PLUGINS)?.toPluginDependencyMap() ?: emptyMap()
+        val orderedTables = (
+            catalog.keys.filter {
+                it == TABLE_VERSIONS || it == TABLE_LIBRARIES || it == TABLE_BUNDLES || it == TABLE_PLUGINS
+            } + DEFAULT_TABLE_ORDER
+            ).distinct()
 
-        return processComments(content, VersionCatalog(versions, libraries, bundles, plugins))
+        return processComments(
+            content,
+            VersionCatalog(
+                versions = versions,
+                libraries = libraries,
+                bundles = bundles,
+                plugins = plugins,
+                tableOrder = orderedTables.toList()
+            )
+        )
     }
 
     private fun processComments(content: String, versionCatalog: VersionCatalog): VersionCatalog {

--- a/catalog/src/main/kotlin/nl/littlerobots/vcu/model/VersionCatalog.kt
+++ b/catalog/src/main/kotlin/nl/littlerobots/vcu/model/VersionCatalog.kt
@@ -14,7 +14,7 @@
 * limitations under the License.
 */
 package nl.littlerobots.vcu.model
-
+import nl.littlerobots.vcu.toml.DEFAULT_TABLE_ORDER
 import nl.littlerobots.vcu.toml.toTomlKey
 
 data class VersionCatalog(
@@ -26,6 +26,7 @@ data class VersionCatalog(
     val libraryComments: Comments = Comments(),
     val bundleComments: Comments = Comments(),
     val pluginComments: Comments = Comments(),
+    internal val tableOrder: List<String> = DEFAULT_TABLE_ORDER
 ) {
     /**
      * The effective version definition of a [HasVersion], resolving [VersionDefinition.Reference]

--- a/catalog/src/main/kotlin/nl/littlerobots/vcu/toml/TomlUtils.kt
+++ b/catalog/src/main/kotlin/nl/littlerobots/vcu/toml/TomlUtils.kt
@@ -16,3 +16,8 @@
 package nl.littlerobots.vcu.toml
 
 internal fun String.toTomlKey() = replace('.', '-')
+internal const val TABLE_VERSIONS = "versions"
+internal const val TABLE_LIBRARIES = "libraries"
+internal const val TABLE_BUNDLES = "bundles"
+internal const val TABLE_PLUGINS = "plugins"
+internal val DEFAULT_TABLE_ORDER = listOf(TABLE_VERSIONS, TABLE_LIBRARIES, TABLE_BUNDLES, TABLE_PLUGINS)

--- a/catalog/src/test/kotlin/nl/littlerobots/vcu/VersionCatalogParserTest.kt
+++ b/catalog/src/test/kotlin/nl/littlerobots/vcu/VersionCatalogParserTest.kt
@@ -18,6 +18,10 @@ package nl.littlerobots.vcu
 import nl.littlerobots.vcu.model.Library
 import nl.littlerobots.vcu.model.Plugin
 import nl.littlerobots.vcu.model.VersionDefinition
+import nl.littlerobots.vcu.toml.TABLE_BUNDLES
+import nl.littlerobots.vcu.toml.TABLE_LIBRARIES
+import nl.littlerobots.vcu.toml.TABLE_PLUGINS
+import nl.littlerobots.vcu.toml.TABLE_VERSIONS
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
 import org.junit.Test
@@ -288,5 +292,39 @@ class VersionCatalogParserTest {
         assertEquals(listOf("# Nice comment"), result.libraryComments.tableComments)
         assertEquals(listOf("# Comment for lib", "# Even more comments"), result.libraryComments.entryComments["lib"])
         assertEquals(listOf("# test bundle comment"), result.bundleComments.entryComments["test"])
+    }
+
+    @Test
+    fun `records the order of the tables`() {
+        val toml = """
+            [libraries]
+            lib = { module = "nl.littlerobots.test:test" }
+
+            [versions]
+            myversion = "1.0"
+
+            [plugins]
+            myplugin = "pluginid:1.0.0"
+
+            [bundles]
+            test = ["lib"]
+
+        """.trimIndent()
+
+        val parser = VersionCatalogParser()
+        val result = parser.parse(toml.byteInputStream())
+        assertEquals(listOf(TABLE_LIBRARIES, TABLE_VERSIONS, TABLE_PLUGINS, TABLE_BUNDLES), result.tableOrder)
+    }
+
+    @Test
+    fun `adds default tables to the the order of the tables`() {
+        val toml = """
+            [libraries]
+            lib = { module = "nl.littlerobots.test:test" }
+        """.trimIndent()
+
+        val parser = VersionCatalogParser()
+        val result = parser.parse(toml.byteInputStream())
+        assertEquals(listOf(TABLE_LIBRARIES, TABLE_VERSIONS, TABLE_BUNDLES, TABLE_PLUGINS), result.tableOrder)
     }
 }

--- a/catalog/src/test/kotlin/nl/littlerobots/vcu/VersionCatalogWriterTest.kt
+++ b/catalog/src/test/kotlin/nl/littlerobots/vcu/VersionCatalogWriterTest.kt
@@ -19,6 +19,10 @@ import nl.littlerobots.vcu.model.Library
 import nl.littlerobots.vcu.model.Plugin
 import nl.littlerobots.vcu.model.VersionCatalog
 import nl.littlerobots.vcu.model.VersionDefinition
+import nl.littlerobots.vcu.toml.TABLE_BUNDLES
+import nl.littlerobots.vcu.toml.TABLE_LIBRARIES
+import nl.littlerobots.vcu.toml.TABLE_PLUGINS
+import nl.littlerobots.vcu.toml.TABLE_VERSIONS
 import org.junit.Assert.assertEquals
 import org.junit.Test
 import java.io.StringWriter
@@ -285,6 +289,43 @@ class VersionCatalogWriterTest {
                 test = [
                     "lib",
                 ]
+
+            """.trimIndent(),
+            writer.toString()
+        )
+    }
+
+    @Test
+    fun `writes the tables in specified order`() {
+        val catalogWriter = VersionCatalogWriter()
+        val writer = StringWriter()
+
+        val toml = """
+            [versions]
+            myversion = "1.0.0"
+            [libraries]
+            lib = { module = "nl.littlerobots.test:test", version = "1.0" }
+            [bundles]
+            test = ["lib"]
+
+            [plugins]
+        """.trimIndent()
+
+        val catalog = VersionCatalogParser().parse(toml.byteInputStream())
+        catalogWriter.write(catalog.copy(tableOrder = listOf(TABLE_PLUGINS, TABLE_BUNDLES, TABLE_LIBRARIES, TABLE_VERSIONS)), writer)
+
+        assertEquals(
+            """
+                [bundles]
+                test = [
+                    "lib",
+                ]
+
+                [libraries]
+                lib = "nl.littlerobots.test:test:1.0"
+
+                [versions]
+                myversion = "1.0.0"
 
             """.trimIndent(),
             writer.toString()


### PR DESCRIPTION
Track the order of tables and apply the same order when writing out the version catalog

ref #113 