### PR TITLE
Fix default version selector

### DIFF
--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdatePlugin.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdatePlugin.kt
@@ -147,7 +147,7 @@ class VersionCatalogUpdatePlugin : Plugin<Project> {
             task.catalogFile.set(versionCatalogConfig.catalogFile.asFile)
             task.notCompatibleWithConfigurationCache("Uses project")
             task.outputs.upToDateWhen { false }
-            val versionSelector = versionCatalogConfig.versionSelector ?: extension.versionSelector ?: VersionSelectors.DEFAULT
+            val versionSelector = versionCatalogConfig.versionSelector ?: extension.versionSelector ?: VersionSelectors.PREFER_STABLE
             task.versionSelector(versionSelector)
         }
     }

--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/resolver/VersionSelectors.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/resolver/VersionSelectors.kt
@@ -34,13 +34,9 @@ class VersionSelectors {
                 return isStable(candidate.candidate.version)
             }
         }
-        val DEFAULT = object : ModuleVersionSelector {
+        val PREFER_STABLE = object : ModuleVersionSelector {
             override fun select(candidate: ModuleVersionCandidate): Boolean {
-                return (isStable(candidate.candidate.version) && isStable(candidate.currentVersion)) || (
-                    !isStable(
-                        candidate.candidate.version
-                    ) && !isStable(candidate.currentVersion)
-                    )
+                return (!isStable(candidate.candidate.version) && !isStable(candidate.currentVersion)) || isStable(candidate.candidate.version)
             }
         }
     }

--- a/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/resolver/DependencyResolverTest.kt
+++ b/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/resolver/DependencyResolverTest.kt
@@ -119,7 +119,7 @@ class DependencyResolverTest {
             project.buildscript.configurations.detachedConfiguration(),
             project.dependencies,
             catalog,
-            VersionSelectors.DEFAULT
+            VersionSelectors.PREFER_STABLE
         )
 
         assertTrue(result.versionCatalog.libraries.isEmpty())
@@ -150,7 +150,7 @@ class DependencyResolverTest {
             project.buildscript.configurations.detachedConfiguration(),
             project.dependencies,
             catalog,
-            VersionSelectors.DEFAULT
+            VersionSelectors.PREFER_STABLE
         )
 
         assertTrue(result.versionCatalog.libraries.isEmpty())


### PR DESCRIPTION
When selecting a version, allow switching to the stable version of a dependency if the current version is unstable.