### PR TITLE
Fix handling of reject version condition in writer and resolver

### DIFF
--- a/catalog/src/main/kotlin/nl/littlerobots/vcu/VersionCatalogParser.kt
+++ b/catalog/src/main/kotlin/nl/littlerobots/vcu/VersionCatalogParser.kt
@@ -175,7 +175,7 @@ private fun Map<String, Any>.toVersionDefinitionMap(): Map<String, VersionDefini
 private fun Any.toDependencyVersion(): VersionDefinition? = when (this) {
     is String -> VersionDefinition.Simple(this)
     is Map<*, *> -> {
-        val stringMap = this as? Map<String, String> ?: throw IllegalStateException("Expected string map")
+        val stringMap = this as? Map<String, Any> ?: throw IllegalStateException("Expected string map")
         if (size == 1 && stringMap.containsKey("ref")) {
             VersionDefinition.Reference(stringMap["ref"] as String)
         } else {

--- a/catalog/src/main/kotlin/nl/littlerobots/vcu/VersionCatalogWriter.kt
+++ b/catalog/src/main/kotlin/nl/littlerobots/vcu/VersionCatalogWriter.kt
@@ -184,7 +184,7 @@ class VersionCatalogWriter {
             StringBuilder("""{ module = "${library.module}", version = { """).apply {
                 val conditions = library.version.definition
                 for (condition in conditions) {
-                    append("${condition.key} = \"${condition.value}\", ")
+                    append("${condition.key} = ${condition.value.formatValue()}, ")
                 }
                 setLength(length - 2)
                 append(" } }")
@@ -198,10 +198,17 @@ class VersionCatalogWriter {
         is VersionDefinition.Simple -> "\"${versionDefinition.version}\""
         is VersionDefinition.Condition -> {
             versionDefinition.definition.entries.joinToString(prefix = "{ ", postfix = " }", separator = ", ") {
-                "${it.key} = \"${it.value}\""
+                "${it.key} = ${it.value.formatValue()}"
             }
         }
 
         else -> throw IllegalStateException("Invalid version definition $versionDefinition")
+    }
+
+    private fun Any.formatValue(): String {
+        return when (this) {
+            is List<*> -> joinToString(", ", prefix = "[", postfix = "]") { "\"${it}\"" }
+            else -> "\"${this}\""
+        }
     }
 }

--- a/catalog/src/main/kotlin/nl/littlerobots/vcu/model/VersionDefinition.kt
+++ b/catalog/src/main/kotlin/nl/littlerobots/vcu/model/VersionDefinition.kt
@@ -18,6 +18,6 @@ package nl.littlerobots.vcu.model
 sealed class VersionDefinition {
     data class Simple(val version: String) : VersionDefinition()
     data class Reference(val ref: String) : VersionDefinition()
-    data class Condition(val definition: Map<String, String>) : VersionDefinition()
+    data class Condition(val definition: Map<String, Any>) : VersionDefinition()
     object Unspecified : VersionDefinition()
 }

--- a/catalog/src/test/kotlin/nl/littlerobots/vcu/VersionCatalogParserTest.kt
+++ b/catalog/src/test/kotlin/nl/littlerobots/vcu/VersionCatalogParserTest.kt
@@ -24,6 +24,7 @@ import nl.littlerobots.vcu.toml.TABLE_PLUGINS
 import nl.littlerobots.vcu.toml.TABLE_VERSIONS
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class VersionCatalogParserTest {
@@ -326,5 +327,22 @@ class VersionCatalogParserTest {
         val parser = VersionCatalogParser()
         val result = parser.parse(toml.byteInputStream())
         assertEquals(listOf(TABLE_LIBRARIES, TABLE_VERSIONS, TABLE_BUNDLES, TABLE_PLUGINS), result.tableOrder)
+    }
+
+    @Test
+    fun `handles reject version condition`() {
+        val toml = """
+            [versions]
+            arrow = { require = "1.1.2", reject = ["1.1.3"] }
+            [libraries]
+            lib = { module = "nl.littlerobots.test:test", version = { reject = ["1.2", "1.3"] } }
+        """.trimIndent()
+
+        val parser = VersionCatalogParser()
+        val result = parser.parse(toml.byteInputStream())
+        assertEquals(1, result.libraries.size)
+        assertEquals(1, result.versions.size)
+        assertTrue(result.versions.values.first() is VersionDefinition.Condition)
+        assertTrue(result.libraries.values.first().version is VersionDefinition.Condition)
     }
 }

--- a/catalog/src/test/kotlin/nl/littlerobots/vcu/VersionCatalogWriterTest.kt
+++ b/catalog/src/test/kotlin/nl/littlerobots/vcu/VersionCatalogWriterTest.kt
@@ -331,4 +331,34 @@ class VersionCatalogWriterTest {
             writer.toString()
         )
     }
+
+    // https://github.com/littlerobots/version-catalog-update-plugin/issues/177
+    @Test
+    fun `writes reject version condition`() {
+        val catalogWriter = VersionCatalogWriter()
+        val writer = StringWriter()
+
+        val toml = """
+            [versions]
+            myversion = { reject = ["1.0","2.0"] }
+
+            [libraries]
+            lib = { module = "nl.littlerobots.test:test", version = { reject = ["1.0"] } }
+        """.trimIndent()
+
+        val catalog = VersionCatalogParser().parse(toml.byteInputStream())
+        catalogWriter.write(catalog, writer)
+
+        assertEquals(
+            """
+                [versions]
+                myversion = { reject = ["1.0", "2.0"] }
+
+                [libraries]
+                lib = { module = "nl.littlerobots.test:test", version = { reject = ["1.0"] } }
+
+            """.trimIndent(),
+            writer.toString()
+        )
+    }
 }

--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/resolver/DependencyResolver.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/resolver/DependencyResolver.kt
@@ -291,17 +291,18 @@ internal class DependencyResolver {
     }
 
     private fun configureConstraint(constraint: DependencyConstraint, richVersion: VersionDefinition.Condition) {
-        val require = richVersion.definition["require"]
-        val reject = richVersion.definition["reject"]
-        val strictly = richVersion.definition["strictly"]
-        val prefer = richVersion.definition["prefer"]
-        val rejectAll = richVersion.definition["rejectAll"]?.toBoolean() ?: false
+        val require = richVersion.definition["require"] as? String
+        @Suppress("UNCHECKED_CAST")
+        val reject = richVersion.definition["reject"] as? List<String>
+        val strictly = richVersion.definition["strictly"] as? String
+        val prefer = richVersion.definition["prefer"] as? String
+        val rejectAll = (richVersion.definition["rejectAll"] as? String)?.toBoolean() ?: false
         constraint.version { version ->
             require?.let {
                 version.require(it)
             }
             reject?.let {
-                version.reject(it)
+                version.reject(*it.toTypedArray())
             }
             strictly?.let {
                 version.strictly(it)


### PR DESCRIPTION
Handle reject condition as a list of versions

Fixes #177