### PR TITLE
Introduce check option to fail the build if there are updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,23 @@ be lost due to parsing the toml file and rewriting it.
 To format the existing `libs.versions.toml` file without updating library versions, you can run `./gradlew versionCatalogFormat`.
 This comes in handy when you added an entry to the version catalog, but aren't ready yet to update any dependencies.
 
+### Checking for updates
+To check for updates to the catalog, failing the build if there are any, use the `--check` flag like so:
+
+```
+./gradlew versionCatalogUpdate --check
+```
+Note that updates to pinned libraries will not fail the build.
+
+To only check updates for a particular library or plugin add the `--library` or `--plugin` flag like so:
+
+```
+./gradlew versionCatalogUpdate --check --library my-library-toml-key
+./gradlew versionCatalogUpdate --check --plugin my-plugin-toml-key
+```
+
+The `--library` and `--plugin` flags can be used multiple times to check updates for multiple libraries or plugins.
+
 ## Informational output
 In some cases the plugin will output some additional messages when checking for updates.
 

--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateTask.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateTask.kt
@@ -64,11 +64,11 @@ abstract class VersionCatalogUpdateTask : DefaultTask() {
     @get:Internal
     abstract var check: Boolean
 
-    @get:Option(option = "libraries", description = "Library keys to check for updates")
+    @get:Option(option = "library", description = "Library keys to check for updates")
     @get:Internal
     abstract val checkLibraryKeys: SetProperty<String>
 
-    @get:Option(option = "plugins", description = "Plugin keys to check for updates")
+    @get:Option(option = "plugin", description = "Plugin keys to check for updates")
     @get:Internal
     abstract val checkPluginKeys: SetProperty<String>
 

--- a/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateTask.kt
+++ b/plugin/src/main/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdateTask.kt
@@ -34,6 +34,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
 import org.gradle.api.artifacts.ModuleIdentifier
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
@@ -58,6 +59,18 @@ abstract class VersionCatalogUpdateTask : DefaultTask() {
     )
     @get:Internal
     abstract var interactive: Boolean
+
+    @set:Option(option = "check", description = "Check and fail the build if there are updates")
+    @get:Internal
+    abstract var check: Boolean
+
+    @get:Option(option = "libraries", description = "Library keys to check for updates")
+    @get:Internal
+    abstract val checkLibraryKeys: SetProperty<String>
+
+    @get:Option(option = "plugins", description = "Plugin keys to check for updates")
+    @get:Internal
+    abstract val checkPluginKeys: SetProperty<String>
 
     @get:Input
     abstract val pins: Property<PinsConfigurationInput>
@@ -154,6 +167,55 @@ abstract class VersionCatalogUpdateTask : DefaultTask() {
                 updatedCatalog,
                 getPinsWithUpdatedVersions(catalogFromDependencies, pins)
             )
+        } else if (check) {
+            val resolvedCurrent = currentCatalog.resolveVersions()
+            val resolvedUpdated = updatedCatalog.resolveVersions()
+            if (resolvedCurrent != resolvedUpdated) {
+                val updatedLibraries = resolvedUpdated.libraries.toMutableMap().apply {
+                    values.removeAll(resolvedCurrent.libraries.values.toSet())
+                }.toMutableMap().apply {
+                    if (checkLibraryKeys.get().isNotEmpty() || checkPluginKeys.get().isNotEmpty()) {
+                        keys.retainAll(checkLibraryKeys.get())
+                    }
+                }
+                val updatedPlugins = resolvedUpdated.plugins.toMutableMap().apply {
+                    values.removeAll(resolvedCurrent.plugins.values.toSet())
+                }.toMutableMap().apply {
+                    if (checkPluginKeys.get().isNotEmpty() || checkLibraryKeys.get().isNotEmpty()) {
+                        keys.retainAll(checkPluginKeys.get())
+                    }
+                }
+
+                if (updatedLibraries.isNotEmpty() ||
+                    updatedPlugins.isNotEmpty()
+                ) {
+
+                    if (updatedLibraries.isNotEmpty()) {
+                        logger.warn("There are libraries that could be updated:")
+                        for (library in updatedLibraries) {
+                            val current = resolvedCurrent.libraries[library.key]
+                            if (current?.version is VersionDefinition.Simple && library.value.version is VersionDefinition.Simple) {
+                                logger.warn(" - ${current.module}:${(current.version as? VersionDefinition.Simple)?.version} (${library.key}) -> ${(library.value.version as VersionDefinition.Simple).version}")
+                            }
+                        }
+                        if (updatedPlugins.isNotEmpty()) {
+                            logger.warn("")
+                        }
+                    }
+
+                    if (updatedPlugins.isNotEmpty()) {
+                        logger.warn("There are plugins that could be updated:")
+                        for (plugin in updatedPlugins) {
+                            val current = resolvedCurrent.plugins[plugin.key]
+                            if (current?.version is VersionDefinition.Simple && plugin.value.version is VersionDefinition.Simple) {
+                                logger.warn(" - ${current.id}:${(current.version as VersionDefinition.Simple).version} (${plugin.key}) -> ${(plugin.value.version as VersionDefinition.Simple).version}")
+                            }
+                        }
+                    }
+
+                    throw GradleException("There are updates available for the version catalog")
+                }
+            }
         } else {
             val writer = VersionCatalogWriter()
             writer.write(updatedCatalog, catalogFile.get().writer())

--- a/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdatePluginTest.kt
+++ b/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdatePluginTest.kt
@@ -1576,7 +1576,7 @@ class VersionCatalogUpdatePluginTest {
 
         val result = GradleRunner.create()
             .withProjectDir(tempDir.root)
-            .withArguments("versionCatalogUpdate", "--check", "--libraries", "test")
+            .withArguments("versionCatalogUpdate", "--check", "--library", "test")
             .withPluginClasspath()
             .withDebug(true)
             .buildAndFail()
@@ -1635,7 +1635,7 @@ class VersionCatalogUpdatePluginTest {
 
         val result = GradleRunner.create()
             .withProjectDir(tempDir.root)
-            .withArguments("versionCatalogUpdate", "--check", "--plugins", "android-library")
+            .withArguments("versionCatalogUpdate", "--check", "--plugin", "android-library")
             .withPluginClasspath()
             .withDebug(true)
             .buildAndFail()

--- a/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdatePluginTest.kt
+++ b/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdatePluginTest.kt
@@ -1407,4 +1407,235 @@ class VersionCatalogUpdatePluginTest {
             tomlFile.readText()
         )
     }
+
+    @Test
+    fun `fails the build when there are updates`() {
+        val m2 = File(javaClass.getResource("/m2/m2.txt")!!.file).absoluteFile.parent
+
+        buildFile.writeText(
+            """
+            buildscript {
+                repositories {
+                    maven {
+                       url = uri("$m2")
+                    }
+                }
+            }
+
+            plugins {
+                id "nl.littlerobots.version-catalog-update"
+            }
+
+            repositories {
+                maven {
+                   url = uri("$m2")
+                }
+            }
+            """.trimIndent()
+        )
+
+        val toml = """
+            [versions]
+            activity-compose = "1.4.0"
+
+            [libraries]
+            test = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
+
+            [plugins]
+            android-library = "com.android.library:8.7.0"
+        """.trimIndent()
+
+        val tomlFile = File(tempDir.root, "gradle/libs.versions.toml")
+        File(tempDir.root, "gradle").mkdir()
+        tomlFile.writeText(toml)
+
+        val result = GradleRunner.create()
+            .withProjectDir(tempDir.root)
+            .withArguments("versionCatalogUpdate", "--check")
+            .withPluginClasspath()
+            .withDebug(true)
+            .buildAndFail()
+
+        assertTrue(
+            result.output.contains(
+                """
+            There are libraries that could be updated:
+             - androidx.activity:activity-compose:1.4.0 (test) -> 1.9.2
+
+            There are plugins that could be updated:
+             - com.android.library:8.7.0 (android-library) -> 8.7.1
+
+                """.trimIndent()
+            )
+        )
+    }
+
+    @Test
+    fun `fails the build when there are updates unless pinned`() {
+        val m2 = File(javaClass.getResource("/m2/m2.txt")!!.file).absoluteFile.parent
+
+        buildFile.writeText(
+            """
+            buildscript {
+                repositories {
+                    maven {
+                       url = uri("$m2")
+                    }
+                }
+            }
+
+            plugins {
+                id "nl.littlerobots.version-catalog-update"
+            }
+
+            repositories {
+                maven {
+                   url = uri("$m2")
+                }
+            }
+            """.trimIndent()
+        )
+
+        val toml = """
+            [versions]
+            activity-compose = "1.4.0"
+
+            [libraries]
+            # @pin
+            test = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
+
+            [plugins]
+            # @pin
+            android-library = "com.android.library:8.7.0"
+        """.trimIndent()
+
+        val tomlFile = File(tempDir.root, "gradle/libs.versions.toml")
+        File(tempDir.root, "gradle").mkdir()
+        tomlFile.writeText(toml)
+
+        GradleRunner.create()
+            .withProjectDir(tempDir.root)
+            .withArguments("versionCatalogUpdate", "--check")
+            .withPluginClasspath()
+            .withDebug(true)
+            .build()
+    }
+
+    @Test
+    fun `fails the build when a specified library is out of date`() {
+        val m2 = File(javaClass.getResource("/m2/m2.txt")!!.file).absoluteFile.parent
+
+        buildFile.writeText(
+            """
+            buildscript {
+                repositories {
+                    maven {
+                       url = uri("$m2")
+                    }
+                }
+            }
+
+            plugins {
+                id "nl.littlerobots.version-catalog-update"
+            }
+
+            repositories {
+                maven {
+                   url = uri("$m2")
+                }
+            }
+            """.trimIndent()
+        )
+
+        val toml = """
+            [versions]
+            activity-compose = "1.4.0"
+
+            [libraries]
+            test = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
+
+            [plugins]
+            android-library = "com.android.library:8.7.0"
+        """.trimIndent()
+
+        val tomlFile = File(tempDir.root, "gradle/libs.versions.toml")
+        File(tempDir.root, "gradle").mkdir()
+        tomlFile.writeText(toml)
+
+        val result = GradleRunner.create()
+            .withProjectDir(tempDir.root)
+            .withArguments("versionCatalogUpdate", "--check", "--libraries", "test")
+            .withPluginClasspath()
+            .withDebug(true)
+            .buildAndFail()
+
+        assertTrue(
+            result.output.contains(
+                """
+            There are libraries that could be updated:
+             - androidx.activity:activity-compose:1.4.0 (test) -> 1.9.2
+
+                """.trimIndent()
+            )
+        )
+    }
+
+    @Test
+    fun `fails the build when a specified plugin is out of date`() {
+        val m2 = File(javaClass.getResource("/m2/m2.txt")!!.file).absoluteFile.parent
+
+        buildFile.writeText(
+            """
+            buildscript {
+                repositories {
+                    maven {
+                       url = uri("$m2")
+                    }
+                }
+            }
+
+            plugins {
+                id "nl.littlerobots.version-catalog-update"
+            }
+
+            repositories {
+                maven {
+                   url = uri("$m2")
+                }
+            }
+            """.trimIndent()
+        )
+
+        val toml = """
+            [versions]
+            activity-compose = "1.4.0"
+
+            [libraries]
+            test = { module = "androidx.activity:activity-compose", version.ref = "activity-compose" }
+
+            [plugins]
+            android-library = "com.android.library:8.7.0"
+        """.trimIndent()
+
+        val tomlFile = File(tempDir.root, "gradle/libs.versions.toml")
+        File(tempDir.root, "gradle").mkdir()
+        tomlFile.writeText(toml)
+
+        val result = GradleRunner.create()
+            .withProjectDir(tempDir.root)
+            .withArguments("versionCatalogUpdate", "--check", "--plugins", "android-library")
+            .withPluginClasspath()
+            .withDebug(true)
+            .buildAndFail()
+
+        assertTrue(
+            result.output.contains(
+                """
+            There are plugins that could be updated:
+             - com.android.library:8.7.0 (android-library) -> 8.7.1
+
+                """.trimIndent()
+            )
+        )
+    }
 }

--- a/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdatePluginTest.kt
+++ b/plugin/src/test/kotlin/nl/littlerobots/vcu/plugin/VersionCatalogUpdatePluginTest.kt
@@ -1513,12 +1513,24 @@ class VersionCatalogUpdatePluginTest {
         File(tempDir.root, "gradle").mkdir()
         tomlFile.writeText(toml)
 
-        GradleRunner.create()
+        val result = GradleRunner.create()
             .withProjectDir(tempDir.root)
             .withArguments("versionCatalogUpdate", "--check")
             .withPluginClasspath()
             .withDebug(true)
             .build()
+
+        assertTrue(
+            result.output.contains(
+                """
+            There are updates available for pinned libraries in the version catalog:
+             - androidx.activity:activity-compose (test) 1.4.0 -> 1.9.2
+            There are updates available for pinned plugins in the version catalog:
+             - com.android.library (android-library) 8.7.0 -> 8.7.1
+
+                """.trimIndent()
+            )
+        )
     }
 
     @Test


### PR DESCRIPTION
Adds a --check with optional --library and/or --plugin arguments to check for updates and fail the build if dependency updates are available.

Pinned versions are considered unchanged for this purpose

example
```
./gradlew versionCatalogUpdate --check --library only-this-library --library also-this-library`
```

Fixes #168 